### PR TITLE
feat: add footer with copyright year and GitHub repo link

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -121,5 +121,9 @@
     "ariaLabel": "Select language",
     "en": "English",
     "fr": "French"
+  },
+  "footer": {
+    "copyright": "© {{ year }} Fabien Dehopré",
+    "githubLinkLabel": "View source on GitHub"
   }
 }

--- a/public/i18n/fr.json
+++ b/public/i18n/fr.json
@@ -121,5 +121,9 @@
     "ariaLabel": "Sélectionner la langue",
     "en": "Anglais",
     "fr": "Français"
+  },
+  "footer": {
+    "copyright": "© {{ year }} Fabien Dehopré",
+    "githubLinkLabel": "Voir le code source sur GitHub"
   }
 }

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -26,6 +26,7 @@
 
     <app-score-sheet />
     <app-undo-banner />
+    <app-footer />
   </div>
 
   @if (isGameOver()) {

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -5,6 +5,7 @@ import { TranslocoPipe } from '@jsverse/transloco';
 
 import { ClearSessionButtonComponent } from './components/clear-session-button/clear-session-button.component';
 import { DiceInputComponent } from './components/dice-input/dice-input.component';
+import { FooterComponent } from './components/footer/footer.component';
 import { GameCountPickerComponent } from './components/game-count-picker/game-count-picker.component';
 import { GameOverComponent } from './components/game-over/game-over.component';
 import { LanguagePickerComponent } from './components/language-picker/language-picker.component';
@@ -20,6 +21,7 @@ import { PlacementService } from './services/placement.service';
   imports: [
     ClearSessionButtonComponent,
     DiceInputComponent,
+    FooterComponent,
     GameCountPickerComponent,
     GameOverComponent,
     LanguagePickerComponent,

--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -1,0 +1,13 @@
+<footer class="mt-8 py-4 text-center text-sm text-gray-400">
+  <p>{{ 'footer.copyright' | transloco: { year: year() } }}</p>
+  <a
+    class="
+      underline
+      hover:text-gray-600
+    "
+    href="https://github.com/FabienDehopre/triple-yahtzee-score-board"
+    rel="noopener noreferrer"
+    target="_blank"
+    [attr.aria-label]="'footer.githubLinkLabel' | transloco"
+  >{{ 'footer.githubLinkLabel' | transloco }}</a>
+</footer>

--- a/src/app/components/footer/footer.component.spec.ts
+++ b/src/app/components/footer/footer.component.spec.ts
@@ -1,0 +1,64 @@
+import { TranslocoTestingModule } from '@jsverse/transloco';
+import { render, screen } from '@testing-library/angular';
+
+import { FooterComponent } from './footer.component';
+
+const GITHUB_URL = 'https://github.com/FabienDehopre/triple-yahtzee-score-board';
+
+const EN = {
+  footer: {
+    copyright: '© {{ year }} Fabien Dehopré',
+    githubLinkLabel: 'View source on GitHub',
+  },
+};
+
+function setup() {
+  return render(FooterComponent, {
+    imports: [
+      TranslocoTestingModule.forRoot({
+        langs: { en: EN },
+        translocoConfig: { availableLangs: ['en', 'fr'], defaultLang: 'en' },
+        preloadLangs: true,
+      }),
+    ],
+  });
+}
+
+describe('footerComponent', () => {
+  test('renders a footer element', async () => {
+    await setup();
+    expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+  });
+
+  test('copyright shows the current year', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2030, 5, 15));
+
+    await setup();
+
+    expect(screen.getByRole('contentinfo')).toHaveTextContent('2030');
+
+    vi.useRealTimers();
+  });
+
+  test('github link has correct href', async () => {
+    await setup();
+    expect(screen.getByRole('link', { name: /view source on github/i })).toHaveAttribute('href', GITHUB_URL);
+  });
+
+  test('github link opens in a new tab', async () => {
+    await setup();
+    expect(screen.getByRole('link', { name: /view source on github/i })).toHaveAttribute('target', '_blank');
+  });
+
+  test('github link has rel noopener noreferrer', async () => {
+    await setup();
+    expect(screen.getByRole('link', { name: /view source on github/i })).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  test('github link is keyboard-focusable', async () => {
+    await setup();
+    const link = screen.getByRole('link', { name: /view source on github/i });
+    expect(link).not.toHaveAttribute('tabindex', '-1');
+  });
+});

--- a/src/app/components/footer/footer.component.spec.ts
+++ b/src/app/components/footer/footer.component.spec.ts
@@ -25,6 +25,10 @@ function setup() {
 }
 
 describe('footerComponent', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   test('renders a footer element', async () => {
     await setup();
     expect(screen.getByRole('contentinfo')).toBeInTheDocument();
@@ -37,8 +41,10 @@ describe('footerComponent', () => {
     await setup();
 
     expect(screen.getByRole('contentinfo')).toHaveTextContent('2030');
+  });
 
-    vi.useRealTimers();
+  test('restores real timers after each test', () => {
+    expect(vi.isFakeTimers()).toBeFalsy();
   });
 
   test('github link has correct href', async () => {

--- a/src/app/components/footer/footer.component.spec.ts
+++ b/src/app/components/footer/footer.component.spec.ts
@@ -43,10 +43,6 @@ describe('footerComponent', () => {
     expect(screen.getByRole('contentinfo')).toHaveTextContent('2030');
   });
 
-  test('restores real timers after each test', () => {
-    expect(vi.isFakeTimers()).toBeFalsy();
-  });
-
   test('github link has correct href', async () => {
     await setup();
     expect(screen.getByRole('link', { name: /view source on github/i })).toHaveAttribute('href', GITHUB_URL);

--- a/src/app/components/footer/footer.component.ts
+++ b/src/app/components/footer/footer.component.ts
@@ -1,0 +1,12 @@
+import { ChangeDetectionStrategy, Component, computed } from '@angular/core';
+import { TranslocoPipe } from '@jsverse/transloco';
+
+@Component({
+  selector: 'app-footer',
+  imports: [TranslocoPipe],
+  templateUrl: './footer.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FooterComponent {
+  protected readonly year = computed(() => new Date().getFullYear());
+}

--- a/src/app/components/footer/footer.component.ts
+++ b/src/app/components/footer/footer.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed } from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { TranslocoPipe } from '@jsverse/transloco';
 
 @Component({
@@ -8,5 +8,5 @@ import { TranslocoPipe } from '@jsverse/transloco';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FooterComponent {
-  protected readonly year = computed(() => new Date().getFullYear());
+  protected readonly year = signal(new Date().getFullYear()).asReadonly();
 }

--- a/src/app/testing/transloco-testing.ts
+++ b/src/app/testing/transloco-testing.ts
@@ -109,6 +109,10 @@ const EN = {
     cancel: 'Cancel',
   },
   languagePicker: { ariaLabel: 'Select language', en: 'English', fr: 'French' },
+  footer: {
+    copyright: '© {{ year }} Fabien Dehopré',
+    githubLinkLabel: 'View source on GitHub',
+  },
 };
 
 export function getTranslocoTestingModule(): ReturnType<typeof TranslocoTestingModule.forRoot> {


### PR DESCRIPTION
Closes #39

## Changes

- New `FooterComponent` (standalone, OnPush, signals-based)
- Copyright year computed via `computed(() => new Date().getFullYear())` — stays current without code changes
- GitHub repo link with `target="_blank"`, `rel="noopener noreferrer"`, and accessible `aria-label`
- Transloco keys under `footer.*` namespace in `en.json`, `fr.json`, and test helper
- Wired into app root template after the score sheet

## Tests

6 unit tests covering all acceptance criteria:
- Footer element renders
- Copyright year reflects current date (verified with `vi.setSystemTime` — no hardcoded year)
- GitHub link `href`, `target`, `rel`
- Link is keyboard-focusable