### PR TITLE
docs: add Potential Score term and sharpen Suggestion

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,8 +66,12 @@ _Avoid_: Number of games, game number
 
 ### Suggestions
 
+**Potential Score**:
+The column-multiplied points the current **DiceSet** would earn in a given available **ScoreCell** if placed there. Defined for every available **ScoreCell** across **all** **Games** (not just the active one). Carries no ranking — it is the raw per-cell fact that the score sheet shows in empty available cells and that a **Suggestion** ranks over.
+_Avoid_: Preview score, projected score, suggestion
+
 **Suggestion**:
-A recommended (ScoreCategory, GameColumn) placement for the current **DiceSet**, ranked by expected score impact.
+The ranked view over the active **Game**'s **Potential Scores** — a recommended (ScoreCategory, GameColumn) placement for the current **DiceSet**, ordered by expected score impact (see **Greedy Strategy**, **Suggestion Scope**).
 _Avoid_: Hint, tip, recommendation
 
 **Greedy Strategy**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -67,7 +67,7 @@ _Avoid_: Number of games, game number
 ### Suggestions
 
 **Potential Score**:
-The column-multiplied points the current **DiceSet** would earn in a given available **ScoreCell** if placed there. Defined for every available **ScoreCell** across **all** **Games** (not just the active one). Carries no ranking — it is the raw per-cell fact that the score sheet shows in empty available cells and that a **Suggestion** ranks over.
+The column-multiplied points the current **DiceSet** would earn in a given available **ScoreCell** if placed there. Defined for every available **ScoreCell** across all **Games** in the current **Session** (not just the active one). Carries no ranking — it is the raw per-cell fact that the score sheet shows in empty available cells and that a **Suggestion** ranks over.
 _Avoid_: Preview score, projected score, suggestion
 
 **Suggestion**:


### PR DESCRIPTION
## What

Adds the **Potential Score** term to `CONTEXT.md` and redefines **Suggestion** in terms of it.

- **Potential Score** — the column-multiplied points the current DiceSet would earn in a given available ScoreCell. Defined for every available cell across **all Games**, unranked. This is the per-cell number the score sheet paints in empty available cells.
- **Suggestion** — now defined as the *ranked view over the active Game's Potential Scores* (behavior unchanged: still ranked, still active-Game-only).

## Why

Came out of triaging #48. The score sheet (all Games, per-cell) and the suggestion bar (active Game, ranked) compute the same underlying fact two different ways. Naming the lower concept (**Potential Score**) shows they are distinct concepts sharing one calculation — so #48 shares that primitive rather than widening **Suggestion Scope** to all Games. Glossary-only; no ADR (the entries carry the reasoning).

Unblocks the #48 agent brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)