### PR TITLE
refactor: route Game cell access through a deep game-cells module

### DIFF
--- a/src/app/components/game-count-picker/game-count-picker.component.spec.ts
+++ b/src/app/components/game-count-picker/game-count-picker.component.spec.ts
@@ -2,6 +2,9 @@ import { TestBed } from '@angular/core/testing';
 import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 
+import { readCell } from '../../models/game-cells';
+import { GAME_COLUMN } from '../../models/game-column.model';
+import { SCORE_CATEGORY } from '../../models/score-category.model';
 import { SessionStore } from '../../services/session.store';
 import { getTranslocoTestingModule } from '../../testing/transloco-testing';
 import { GameCountPickerComponent } from './game-count-picker.component';
@@ -89,7 +92,7 @@ describe('gameCountPickerComponent', () => {
     await user.selectOptions(screen.getByTestId('game-count-select'), '3');
 
     expect(sessionStore.games()).toHaveLength(3);
-    expect(sessionStore.games()[0].columns.ONE.upper.Aces?.value).toBe(3);
+    expect(readCell(sessionStore.games()[0], GAME_COLUMN.one, SCORE_CATEGORY.aces)?.value).toBe(3);
   });
 
   // ─── Decreasing game count with empty trailing games ───────────────────────
@@ -119,7 +122,7 @@ describe('gameCountPickerComponent', () => {
 
     await user.selectOptions(screen.getByTestId('game-count-select'), '1');
 
-    expect(sessionStore.games()[0].columns.ONE.upper.Aces?.value).toBe(3);
+    expect(readCell(sessionStore.games()[0], GAME_COLUMN.one, SCORE_CATEGORY.aces)?.value).toBe(3);
   });
 
   // ─── Decreasing game count with scored trailing games ──────────────────────

--- a/src/app/components/game-over/game-over.component.spec.ts
+++ b/src/app/components/game-over/game-over.component.spec.ts
@@ -4,6 +4,7 @@ import { TestBed } from '@angular/core/testing';
 import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 
+import { readCell } from '../../models/game-cells';
 import { GAME_COLUMN, LOWER_CATEGORIES, UPPER_CATEGORIES } from '../../models/game-column.model';
 import { SCORE_CATEGORY } from '../../models/score-category.model';
 import { SessionStore } from '../../services/session.store';
@@ -137,7 +138,7 @@ describe('gameOverComponent', () => {
     await user.click(screen.getByTestId('new-game-button'));
 
     // Game state should be reset
-    expect(sessionStore.games()[0].columns[GAME_COLUMN.one].upper[SCORE_CATEGORY.aces]).toBeUndefined();
+    expect(readCell(sessionStore.games()[0], GAME_COLUMN.one, SCORE_CATEGORY.aces)).toBeUndefined();
     expect(sessionStore.currentDice()).toBeUndefined();
     expect(sessionStore.grandTotal()).toBe(0);
   });

--- a/src/app/components/score-sheet/score-sheet.component.ts
+++ b/src/app/components/score-sheet/score-sheet.component.ts
@@ -4,13 +4,12 @@ import type { ScoreCategory } from '../../models/score-category.model';
 import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 import { TranslocoPipe } from '@jsverse/transloco';
 
+import { readCell } from '../../models/game-cells';
 import { COLUMN_ORDER, LOWER_CATEGORIES, UPPER_CATEGORIES } from '../../models/game-column.model';
 import { nextUnfilledColumn } from '../../models/game.model';
 import { CATEGORY_HINT_KEYS, CATEGORY_LABEL_KEYS, SCORE_SHEET_COLUMN_KEYS } from '../../models/i18n-keys';
 import { ScoringEngineService } from '../../services/scoring-engine.service';
 import { SessionStore } from '../../services/session.store';
-
-const UPPER_SET = new Set<ScoreCategory>(UPPER_CATEGORIES);
 
 @Component({
   selector: 'app-score-sheet',
@@ -40,10 +39,7 @@ export class ScoreSheetComponent {
   protected readonly categoryHintKeys = CATEGORY_HINT_KEYS;
 
   protected getCellDisplayValue(gameIndex: number, column: GameColumn, category: ScoreCategory): number | undefined {
-    const game = this.games()[gameIndex];
-    const isUpper = UPPER_SET.has(category);
-    const section = isUpper ? game.columns[column].upper : game.columns[column].lower;
-    const cell = section[category];
+    const cell = readCell(this.games()[gameIndex], column, category);
     if (cell === undefined) return undefined;
     return this.#scoringEngine.applyMultiplier(cell.value, column);
   }

--- a/src/app/components/suggestion-bar/suggestion-bar.component.spec.ts
+++ b/src/app/components/suggestion-bar/suggestion-bar.component.spec.ts
@@ -4,6 +4,8 @@ import { TestBed } from '@angular/core/testing';
 import { render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 
+import { columnCells, readCell } from '../../models/game-cells';
+import { GAME_COLUMN } from '../../models/game-column.model';
 import { SCORE_CATEGORY } from '../../models/score-category.model';
 import { SessionStore } from '../../services/session.store';
 import { getTranslocoTestingModule } from '../../testing/transloco-testing';
@@ -97,7 +99,7 @@ describe('suggestionBarComponent', () => {
     await user.click(screen.getByRole('button', { name: 'Accept suggestion' }));
 
     const game = sessionStore.games()[0];
-    expect(game.columns.ONE.lower[SCORE_CATEGORY.yahtzee]).toEqual({
+    expect(readCell(game, GAME_COLUMN.one, SCORE_CATEGORY.yahtzee)).toEqual({
       value: 50,
       isScratched: false,
     });
@@ -116,11 +118,11 @@ describe('suggestionBarComponent', () => {
 
     await user.click(screen.getByRole('button', { name: 'Accept suggestion' }));
 
-    expect(sessionStore.games()[1].columns.ONE.lower[SCORE_CATEGORY.yahtzee]).toEqual({
+    expect(readCell(sessionStore.games()[1], GAME_COLUMN.one, SCORE_CATEGORY.yahtzee)).toEqual({
       value: 50,
       isScratched: false,
     });
-    expect(sessionStore.games()[0].columns.ONE.lower[SCORE_CATEGORY.yahtzee]).toBeUndefined();
+    expect(readCell(sessionStore.games()[0], GAME_COLUMN.one, SCORE_CATEGORY.yahtzee)).toBeUndefined();
   });
 
   // ─── Dismiss button ───────────────────────────────────────────────────────
@@ -152,8 +154,8 @@ describe('suggestionBarComponent', () => {
 
     const game = sessionStore.games()[0];
     // No score should have been placed in any category
-    const allFilled = [...Object.values(game.columns.ONE.upper), ...Object.values(game.columns.ONE.lower)];
-    expect(allFilled).toHaveLength(0);
+    const filled = [...columnCells(game, GAME_COLUMN.one)].filter((entry) => entry.cell !== undefined);
+    expect(filled).toHaveLength(0);
   });
 
   // ─── Re-appear on new dice roll ───────────────────────────────────────────

--- a/src/app/components/undo-banner/undo-banner.component.spec.ts
+++ b/src/app/components/undo-banner/undo-banner.component.spec.ts
@@ -4,6 +4,8 @@ import { TestBed } from '@angular/core/testing';
 import { render, screen, waitFor } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 
+import { readCell } from '../../models/game-cells';
+import { GAME_COLUMN } from '../../models/game-column.model';
 import { SCORE_CATEGORY } from '../../models/score-category.model';
 import { SessionStore } from '../../services/session.store';
 import { UndoStore } from '../../services/undo.store';
@@ -75,7 +77,7 @@ describe('undoBannerComponent', () => {
 
     await user.click(await screen.findByRole('button', { name: /undo/i }));
 
-    expect(sessionStore.games()[0].columns.ONE.upper[SCORE_CATEGORY.aces]).toBeUndefined();
+    expect(readCell(sessionStore.games()[0], GAME_COLUMN.one, SCORE_CATEGORY.aces)).toBeUndefined();
   });
 
   // ─── Auto-hide on new dice ─────────────────────────────────────────────────

--- a/src/app/models/game-cells.spec.ts
+++ b/src/app/models/game-cells.spec.ts
@@ -1,0 +1,131 @@
+import type { Game } from './game.model';
+
+import { addYahtzeeBonus, eachCell, readCell, sectionOf, writeCell } from './game-cells';
+import { GAME_COLUMN } from './game-column.model';
+import { SCORE_CATEGORY } from './score-category.model';
+
+function emptyGame(): Game {
+  return {
+    id: 'g1',
+    createdAt: '',
+    columns: {
+      [GAME_COLUMN.one]: { upper: {}, lower: {}, yahtzeeBonus: 0 },
+      [GAME_COLUMN.two]: { upper: {}, lower: {}, yahtzeeBonus: 0 },
+      [GAME_COLUMN.three]: { upper: {}, lower: {}, yahtzeeBonus: 0 },
+    },
+  };
+}
+
+describe('sectionOf', () => {
+  test('should resolve upper categories to the upper section', () => {
+    expect(sectionOf(SCORE_CATEGORY.aces)).toBe('upper');
+    expect(sectionOf(SCORE_CATEGORY.sixes)).toBe('upper');
+  });
+
+  test('should resolve lower categories to the lower section', () => {
+    expect(sectionOf(SCORE_CATEGORY.yahtzee)).toBe('lower');
+    expect(sectionOf(SCORE_CATEGORY.chance)).toBe('lower');
+    expect(sectionOf(SCORE_CATEGORY.threeOfAKind)).toBe('lower');
+  });
+});
+
+describe('readCell', () => {
+  test('should return undefined for an empty cell', () => {
+    expect(readCell(emptyGame(), GAME_COLUMN.one, SCORE_CATEGORY.aces)).toBeUndefined();
+  });
+
+  test('should read an upper-section cell without the caller naming the section', () => {
+    const game = emptyGame();
+    game.columns[GAME_COLUMN.one].upper[SCORE_CATEGORY.aces] = { value: 5, isScratched: false };
+    expect(readCell(game, GAME_COLUMN.one, SCORE_CATEGORY.aces)).toEqual({ value: 5, isScratched: false });
+  });
+
+  test('should read a lower-section cell without the caller naming the section', () => {
+    const game = emptyGame();
+    game.columns[GAME_COLUMN.two].lower[SCORE_CATEGORY.yahtzee] = { value: 50, isScratched: false };
+    expect(readCell(game, GAME_COLUMN.two, SCORE_CATEGORY.yahtzee)).toEqual({ value: 50, isScratched: false });
+  });
+});
+
+describe('writeCell', () => {
+  test('should return a new Game with the one cell set', () => {
+    const game = emptyGame();
+    const next = writeCell(game, GAME_COLUMN.one, SCORE_CATEGORY.aces, { value: 3, isScratched: false });
+    expect(readCell(next, GAME_COLUMN.one, SCORE_CATEGORY.aces)).toEqual({ value: 3, isScratched: false });
+  });
+
+  test('should not mutate the original Game', () => {
+    const game = emptyGame();
+    writeCell(game, GAME_COLUMN.one, SCORE_CATEGORY.aces, { value: 3, isScratched: false });
+    expect(readCell(game, GAME_COLUMN.one, SCORE_CATEGORY.aces)).toBeUndefined();
+  });
+
+  test('should route a lower category into the lower section', () => {
+    const game = emptyGame();
+    const next = writeCell(game, GAME_COLUMN.one, SCORE_CATEGORY.yahtzee, { value: 50, isScratched: false });
+    expect(next.columns[GAME_COLUMN.one].lower[SCORE_CATEGORY.yahtzee]).toEqual({ value: 50, isScratched: false });
+    expect(next.columns[GAME_COLUMN.one].upper[SCORE_CATEGORY.yahtzee]).toBeUndefined();
+  });
+
+  test('should structurally share untouched columns', () => {
+    const game = emptyGame();
+    const next = writeCell(game, GAME_COLUMN.one, SCORE_CATEGORY.aces, { value: 3, isScratched: false });
+    expect(next.columns[GAME_COLUMN.two]).toBe(game.columns[GAME_COLUMN.two]);
+    expect(next.columns[GAME_COLUMN.three]).toBe(game.columns[GAME_COLUMN.three]);
+  });
+
+  test('should preserve the accumulated yahtzee bonus of the written column', () => {
+    const game = emptyGame();
+    game.columns[GAME_COLUMN.one].yahtzeeBonus = 100;
+    const next = writeCell(game, GAME_COLUMN.one, SCORE_CATEGORY.aces, { value: 3, isScratched: false });
+    expect(next.columns[GAME_COLUMN.one].yahtzeeBonus).toBe(100);
+  });
+});
+
+describe('addYahtzeeBonus', () => {
+  test('should add the bonus to the column, returning a new Game', () => {
+    const game = emptyGame();
+    const next = addYahtzeeBonus(game, GAME_COLUMN.one, 100);
+    expect(next.columns[GAME_COLUMN.one].yahtzeeBonus).toBe(100);
+    expect(game.columns[GAME_COLUMN.one].yahtzeeBonus).toBe(0);
+  });
+
+  test('should accumulate on top of an existing bonus', () => {
+    const game = emptyGame();
+    game.columns[GAME_COLUMN.one].yahtzeeBonus = 100;
+    const next = addYahtzeeBonus(game, GAME_COLUMN.one, 100);
+    expect(next.columns[GAME_COLUMN.one].yahtzeeBonus).toBe(200);
+  });
+
+  test('should treat a missing bonus as zero', () => {
+    const game = emptyGame();
+    delete game.columns[GAME_COLUMN.one].yahtzeeBonus;
+    const next = addYahtzeeBonus(game, GAME_COLUMN.one, 100);
+    expect(next.columns[GAME_COLUMN.one].yahtzeeBonus).toBe(100);
+  });
+});
+
+describe('eachCell', () => {
+  test('should visit all 13 cells of every column (39 cells total)', () => {
+    const entries = [...eachCell(emptyGame())];
+    expect(entries).toHaveLength(39);
+  });
+
+  test('should report the resolved section for each cell', () => {
+    const entries = [...eachCell(emptyGame())];
+    const aces = entries.find((e) => e.column === GAME_COLUMN.one && e.category === SCORE_CATEGORY.aces);
+    const yahtzee = entries.find((e) => e.column === GAME_COLUMN.one && e.category === SCORE_CATEGORY.yahtzee);
+    expect(aces?.section).toBe('upper');
+    expect(yahtzee?.section).toBe('lower');
+  });
+
+  test('should surface the cell value when filled and undefined when empty', () => {
+    const game = emptyGame();
+    game.columns[GAME_COLUMN.one].upper[SCORE_CATEGORY.aces] = { value: 5, isScratched: false };
+    const entries = [...eachCell(game)];
+    const filled = entries.find((e) => e.column === GAME_COLUMN.one && e.category === SCORE_CATEGORY.aces);
+    const empty = entries.find((e) => e.column === GAME_COLUMN.one && e.category === SCORE_CATEGORY.twos);
+    expect(filled?.cell).toEqual({ value: 5, isScratched: false });
+    expect(empty?.cell).toBeUndefined();
+  });
+});

--- a/src/app/models/game-cells.ts
+++ b/src/app/models/game-cells.ts
@@ -1,0 +1,86 @@
+import type { ColumnScores, GameColumn } from './game-column.model';
+import type { Game } from './game.model';
+import type { ScoreCategory } from './score-category.model';
+import type { ScoreCell } from './score-cell.model';
+
+import { COLUMN_ORDER, LOWER_CATEGORIES, UPPER_CATEGORIES } from './game-column.model';
+
+/**
+ * The single deep module that owns Game-cell access: section resolution,
+ * cell read, immutable cell write, and grid iteration. No other module
+ * indexes `columns.upper` / `columns.lower` or rebuilds an upper-category set.
+ */
+
+/** The two sections of a game column. */
+export type Section = keyof Pick<ColumnScores, 'lower' | 'upper'>;
+
+/** The single source of upper/lower membership. */
+const UPPER_SET = new Set<ScoreCategory>(UPPER_CATEGORIES);
+
+/** One cell visited during grid iteration, with its resolved section. */
+export interface CellEntry {
+  column: GameColumn;
+  category: ScoreCategory;
+  section: Section;
+  /** The cell value, or undefined when the cell is empty. */
+  cell: ScoreCell | undefined;
+}
+
+/** Resolves which section a category belongs to — replaces every ad-hoc `new Set(UPPER_CATEGORIES)`. */
+export function sectionOf(category: ScoreCategory): Section {
+  return UPPER_SET.has(category) ? 'upper' : 'lower';
+}
+
+/** Reads one cell, or undefined when empty. The caller never names the section. */
+export function readCell(game: Game, column: GameColumn, category: ScoreCategory): ScoreCell | undefined {
+  return game.columns[column][sectionOf(category)][category];
+}
+
+/**
+ * Returns a new Game with the one cell set, structurally sharing the rest.
+ * Writes a single cell only — Yahtzee-bonus accumulation stays the caller's
+ * concern (see {@link addYahtzeeBonus}).
+ */
+export function writeCell(game: Game, column: GameColumn, category: ScoreCategory, cell: ScoreCell): Game {
+  const section = sectionOf(category);
+  const col = game.columns[column];
+  return {
+    ...game,
+    columns: {
+      ...game.columns,
+      [column]: {
+        ...col,
+        [section]: { ...col[section], [category]: cell },
+      },
+    },
+  };
+}
+
+/** Returns a new Game with `amount` added to the column's accumulated Yahtzee bonus. */
+export function addYahtzeeBonus(game: Game, column: GameColumn, amount: number): Game {
+  const col = game.columns[column];
+  return {
+    ...game,
+    columns: {
+      ...game.columns,
+      [column]: { ...col, yahtzeeBonus: (col.yahtzeeBonus ?? 0) + amount },
+    },
+  };
+}
+
+/** Visits the cells of one column in upper-then-lower category order. */
+export function* columnCells(game: Game, column: GameColumn): Generator<CellEntry> {
+  for (const category of UPPER_CATEGORIES) {
+    yield { column, category, section: 'upper', cell: game.columns[column].upper[category] };
+  }
+  for (const category of LOWER_CATEGORIES) {
+    yield { column, category, section: 'lower', cell: game.columns[column].lower[category] };
+  }
+}
+
+/** Visits every cell of the game, column by column, upper-then-lower within each. */
+export function* eachCell(game: Game): Generator<CellEntry> {
+  for (const column of COLUMN_ORDER) {
+    yield* columnCells(game, column);
+  }
+}

--- a/src/app/models/game.model.ts
+++ b/src/app/models/game.model.ts
@@ -1,7 +1,8 @@
 import type { ColumnScores, GameColumn } from './game-column.model';
 import type { ScoreCategory } from './score-category.model';
 
-import { COLUMN_ORDER, UPPER_CATEGORIES } from './game-column.model';
+import { readCell } from './game-cells';
+import { COLUMN_ORDER } from './game-column.model';
 
 /**
  * Represents a complete Triple Yahtzee game session.
@@ -16,19 +17,14 @@ export interface Game {
   createdAt: string;
 }
 
-/** Lookup set for upper-section categories, used by nextUnfilledColumn. */
-const UPPER_SET = new Set(UPPER_CATEGORIES);
-
 /**
  * Returns the leftmost unfilled column for the given category in the given game.
  * Columns are checked in left-to-right order: ONE → TWO → THREE.
  * Returns undefined when all three columns are already filled.
  */
 export function nextUnfilledColumn(game: Game, category: ScoreCategory): GameColumn | undefined {
-  const isUpper = UPPER_SET.has(category);
   for (const col of COLUMN_ORDER) {
-    const section = isUpper ? game.columns[col].upper : game.columns[col].lower;
-    if (!section[category]) return col;
+    if (!readCell(game, col, category)) return col;
   }
   return undefined;
 }

--- a/src/app/services/game-state-anonymizer.service.spec.ts
+++ b/src/app/services/game-state-anonymizer.service.spec.ts
@@ -2,6 +2,7 @@ import type { Game } from '../models/game.model';
 
 import { TestBed } from '@angular/core/testing';
 
+import { readCell } from '../models/game-cells';
 import { GAME_COLUMN } from '../models/game-column.model';
 import { SCORE_CATEGORY } from '../models/score-category.model';
 import { GameStateAnonymizerService } from './game-state-anonymizer.service';
@@ -70,10 +71,10 @@ describe('gameStateAnonymizerService', () => {
     test('preserves all scores, yahtzeeBonus, and isScratched flags', () => {
       const games = [makeGameWithScores('real-uuid')];
       const { anonymizedGames } = service.anonymize(games);
-      const col = anonymizedGames[0].columns[GAME_COLUMN.one];
-      expect(col.upper[SCORE_CATEGORY.aces]).toEqual({ value: 3, isScratched: false });
-      expect(col.lower[SCORE_CATEGORY.yahtzee]).toEqual({ value: 50, isScratched: false });
-      expect(col.yahtzeeBonus).toBe(100);
+      const game = anonymizedGames[0];
+      expect(readCell(game, GAME_COLUMN.one, SCORE_CATEGORY.aces)).toEqual({ value: 3, isScratched: false });
+      expect(readCell(game, GAME_COLUMN.one, SCORE_CATEGORY.yahtzee)).toEqual({ value: 50, isScratched: false });
+      expect(game.columns[GAME_COLUMN.one].yahtzeeBonus).toBe(100);
     });
 
     test('does not mutate the original games array', () => {

--- a/src/app/services/scoring-engine.service.ts
+++ b/src/app/services/scoring-engine.service.ts
@@ -6,7 +6,8 @@ import type { ScoreCategory } from '../models/score-category.model';
 
 import { Injectable } from '@angular/core';
 
-import { COLUMN_MULTIPLIER, LOWER_CATEGORIES, UPPER_CATEGORIES } from '../models/game-column.model';
+import { columnCells } from '../models/game-cells';
+import { COLUMN_MULTIPLIER } from '../models/game-column.model';
 import { SCORE_CATEGORY } from '../models/score-category.model';
 
 /** Points awarded for reaching the upper-section bonus threshold. */
@@ -118,23 +119,19 @@ export class ScoringEngineService {
    */
   computeColumnStats(game: Game, column: GameColumn): ColumnStats {
     const multiplier = COLUMN_MULTIPLIER[column];
-    const colScores = game.columns[column];
 
     let upperRaw = 0;
-    for (const cat of UPPER_CATEGORIES) {
-      upperRaw += colScores.upper[cat]?.value ?? 0;
+    let lowerRaw = 0;
+    for (const { section, cell } of columnCells(game, column)) {
+      if (section === 'upper') upperRaw += cell?.value ?? 0;
+      else lowerRaw += cell?.value ?? 0;
     }
 
     const upperBonusRaw = this.computeUpperBonus(upperRaw);
     const upperBonusTotal = upperBonusRaw * multiplier;
     const upperTotal = (upperRaw + upperBonusRaw) * multiplier;
 
-    let lowerRaw = 0;
-    for (const cat of LOWER_CATEGORIES) {
-      lowerRaw += colScores.lower[cat]?.value ?? 0;
-    }
-
-    const yahtzeeBonusRaw = colScores.yahtzeeBonus ?? 0;
+    const yahtzeeBonusRaw = game.columns[column].yahtzeeBonus ?? 0;
     const yahtzeeBonusTotal = yahtzeeBonusRaw * multiplier;
     const lowerTotal = (lowerRaw + yahtzeeBonusRaw) * multiplier;
     const combinedTotal = upperTotal + lowerTotal;

--- a/src/app/services/session.store.spec.ts
+++ b/src/app/services/session.store.spec.ts
@@ -2,6 +2,7 @@ import type { DiceSet } from '../models/dice-set.model';
 
 import { TestBed } from '@angular/core/testing';
 
+import { readCell } from '../models/game-cells';
 import { GAME_COLUMN } from '../models/game-column.model';
 import { SCORE_CATEGORY } from '../models/score-category.model';
 import { SessionStore } from './session.store';
@@ -75,7 +76,7 @@ describe('sessionStore', () => {
       store.setCurrentDice([5, 0, 0, 0, 0, 0] as DiceSet);
       store.placeScore(SCORE_CATEGORY.aces, 0);
 
-      expect(store.games()[0].columns.ONE.upper[SCORE_CATEGORY.aces]).toEqual({
+      expect(readCell(store.games()[0], GAME_COLUMN.one, SCORE_CATEGORY.aces)).toEqual({
         value: 5,
         isScratched: false,
       });
@@ -88,7 +89,7 @@ describe('sessionStore', () => {
       store.setCurrentDice(dice);
       store.placeScore(SCORE_CATEGORY.aces, 0);
 
-      expect(store.games()[0].columns.TWO.upper[SCORE_CATEGORY.aces]).toBeDefined();
+      expect(readCell(store.games()[0], GAME_COLUMN.two, SCORE_CATEGORY.aces)).toBeDefined();
     });
 
     test('should clear currentDice after placement', () => {
@@ -101,7 +102,7 @@ describe('sessionStore', () => {
       store.setCurrentDice([0, 5, 0, 0, 0, 0] as DiceSet); // no aces
       store.placeScore(SCORE_CATEGORY.aces, 0);
 
-      const cell = store.games()[0].columns.ONE.upper[SCORE_CATEGORY.aces];
+      const cell = readCell(store.games()[0], GAME_COLUMN.one, SCORE_CATEGORY.aces);
       expect(cell?.value).toBe(0);
       expect(cell?.isScratched).toBeTruthy();
     });
@@ -119,8 +120,8 @@ describe('sessionStore', () => {
       store.setCurrentDice([5, 0, 0, 0, 0, 0] as DiceSet);
       store.placeScore(SCORE_CATEGORY.aces, 1);
 
-      expect(store.games()[1].columns.ONE.upper[SCORE_CATEGORY.aces]).toBeDefined();
-      expect(store.games()[0].columns.ONE.upper[SCORE_CATEGORY.aces]).toBeUndefined();
+      expect(readCell(store.games()[1], GAME_COLUMN.one, SCORE_CATEGORY.aces)).toBeDefined();
+      expect(readCell(store.games()[0], GAME_COLUMN.one, SCORE_CATEGORY.aces)).toBeUndefined();
     });
 
     test('should accumulate Yahtzee Bonus on second yahtzee', () => {
@@ -141,10 +142,10 @@ describe('sessionStore', () => {
     test('should restore previous game state', () => {
       store.setCurrentDice([5, 0, 0, 0, 0, 0] as DiceSet);
       store.placeScore(SCORE_CATEGORY.aces, 0);
-      expect(store.games()[0].columns.ONE.upper[SCORE_CATEGORY.aces]).toBeDefined();
+      expect(readCell(store.games()[0], GAME_COLUMN.one, SCORE_CATEGORY.aces)).toBeDefined();
 
       store.undo();
-      expect(store.games()[0].columns.ONE.upper[SCORE_CATEGORY.aces]).toBeUndefined();
+      expect(readCell(store.games()[0], GAME_COLUMN.one, SCORE_CATEGORY.aces)).toBeUndefined();
     });
 
     test('should clear undo snapshot after undo', () => {
@@ -171,7 +172,7 @@ describe('sessionStore', () => {
       store.placeScore(SCORE_CATEGORY.aces, 0);
       store.newGame();
 
-      expect(store.games()[0].columns.ONE.upper[SCORE_CATEGORY.aces]).toBeUndefined();
+      expect(readCell(store.games()[0], GAME_COLUMN.one, SCORE_CATEGORY.aces)).toBeUndefined();
     });
 
     test('should clear currentDice', () => {
@@ -213,7 +214,7 @@ describe('sessionStore', () => {
       store.setCurrentDice([5, 0, 0, 0, 0, 0] as DiceSet);
       store.placeScore(SCORE_CATEGORY.aces, 0);
       store.setGameCount(3);
-      expect(store.games()[0].columns.ONE.upper[SCORE_CATEGORY.aces]).toBeDefined();
+      expect(readCell(store.games()[0], GAME_COLUMN.one, SCORE_CATEGORY.aces)).toBeDefined();
     });
   });
 

--- a/src/app/services/session.store.ts
+++ b/src/app/services/session.store.ts
@@ -8,12 +8,8 @@ import { withStorageSync } from '@angular-architects/ngrx-toolkit';
 import { computed, inject } from '@angular/core';
 import { patchState, signalStore, withComputed, withMethods, withState } from '@ngrx/signals';
 
-import {
-  COLUMN_ORDER,
-  GAME_COLUMN,
-  LOWER_CATEGORIES,
-  UPPER_CATEGORIES
-} from '../models/game-column.model';
+import { addYahtzeeBonus, eachCell, readCell, writeCell } from '../models/game-cells';
+import { COLUMN_ORDER, GAME_COLUMN } from '../models/game-column.model';
 import { nextUnfilledColumn } from '../models/game.model';
 import { SCORE_CATEGORY } from '../models/score-category.model';
 import { ScoringEngineService } from './scoring-engine.service';
@@ -22,8 +18,6 @@ import { UndoStore } from './undo.store';
 
 const PERSISTENCE_KEY = 'triple-yahtzee-state';
 const DEFAULT_GAME_COUNT = 2;
-
-const UPPER_SET = new Set(UPPER_CATEGORIES);
 
 function createEmptyGame(): Game {
   return {
@@ -61,14 +55,8 @@ function isValidPersistedState(value: unknown): value is PersistedState {
 
 function hasAnyScore(games: Game[], fromIndex = 0): boolean {
   for (let i = fromIndex; i < games.length; i++) {
-    const game = games[i];
-    for (const col of COLUMN_ORDER) {
-      for (const cat of UPPER_CATEGORIES) {
-        if (game.columns[col].upper[cat] !== undefined) return true;
-      }
-      for (const cat of LOWER_CATEGORIES) {
-        if (game.columns[col].lower[cat] !== undefined) return true;
-      }
+    for (const { cell } of eachCell(games[i])) {
+      if (cell !== undefined) return true;
     }
   }
   return false;
@@ -77,13 +65,8 @@ function hasAnyScore(games: Game[], fromIndex = 0): boolean {
 function allCellsFilled(games: Game[]): boolean {
   if (games.length === 0) return false;
   for (const game of games) {
-    for (const col of COLUMN_ORDER) {
-      for (const cat of UPPER_CATEGORIES) {
-        if (game.columns[col].upper[cat] === undefined) return false;
-      }
-      for (const cat of LOWER_CATEGORIES) {
-        if (game.columns[col].lower[cat] === undefined) return false;
-      }
+    for (const { cell } of eachCell(game)) {
+      if (cell === undefined) return false;
     }
   }
   return true;
@@ -174,33 +157,20 @@ export const SessionStore = signalStore(
         undoStore.saveSnapshot(games, category);
 
         const rawScore = scoringEngine.computeScore(dice, category);
-        const sectionKey = UPPER_SET.has(category) ? 'upper' : 'lower';
 
-        const yahtzeeCell = game.columns[column].lower[SCORE_CATEGORY.yahtzee];
+        const yahtzeeCell = readCell(game, column, SCORE_CATEGORY.yahtzee);
         const bonusEarned =
           yahtzeeCell === undefined
             ? 0
             : scoringEngine.computeYahtzeeBonus(dice, yahtzeeCell.value);
 
+        let updated = writeCell(game, column, category, { value: rawScore, isScratched: rawScore === 0 });
+        if (bonusEarned !== 0) {
+          updated = addYahtzeeBonus(updated, column, bonusEarned);
+        }
+
         patchState(store, {
-          games: games.map((g, i) =>
-            i === gameIndex
-              ? {
-                  ...g,
-                  columns: {
-                    ...g.columns,
-                    [column]: {
-                      ...g.columns[column],
-                      yahtzeeBonus: (g.columns[column].yahtzeeBonus ?? 0) + bonusEarned,
-                      [sectionKey]: {
-                        ...g.columns[column][sectionKey],
-                        [category]: { value: rawScore, isScratched: rawScore === 0 },
-                      },
-                    },
-                  },
-                }
-              : g
-          ),
+          games: games.map((g, i) => (i === gameIndex ? updated : g)),
           currentDice: undefined,
         });
       },


### PR DESCRIPTION
Closes #47

## What

Adds a single deep, pure module — `src/app/models/game-cells.ts` — that owns all `Game`-cell access: section resolution, cell read, immutable cell write, and grid iteration. Every caller stops touching `columns.upper` / `columns.lower` directly, and the `UPPER_SET` lookup (previously rebuilt in three modules) is now resolved in exactly one place.

This is a pure refactor — app behavior (scores, totals, suggestions, undo, persistence) and the persisted `Game` JSON shape are unchanged. Placement coordination stays in `SessionStore` per ADR-0008/ADR-0006; the store now *calls* this module to perform the write rather than hand-rolling a nested spread.

## Module interface

- `sectionOf(category)` — the single source of upper/lower membership.
- `readCell(game, column, category)` — read one cell; caller never names the section.
- `writeCell(game, column, category, cell)` — return a new `Game` with one cell set, structurally sharing the rest.
- `addYahtzeeBonus(game, column, amount)` — immutable column-bonus write (bonus accumulation stays the caller's concern).
- `columnCells(game, column)` / `eachCell(game)` — grid iteration generators.

## Call sites updated

- `game.model.ts` — `nextUnfilledColumn` uses `readCell`; drops its `UPPER_SET`.
- `session.store.ts` — `hasAnyScore` / `allCellsFilled` iterate via `eachCell`; `placeScore` writes via a single `writeCell` (+ `addYahtzeeBonus`), no inline nested `columns`/`upper`/`lower` spread; drops its `UPPER_SET`.
- `scoring-engine.service.ts` — `computeColumnStats` walks `columnCells`.
- `score-sheet.component.ts` — `getCellDisplayValue` uses `readCell`; drops its `UPPER_SET`.
- Specs that asserted individual cell values now read through `readCell` instead of reaching into `.columns.X.upper[cat]`. Setup writes stay as fixtures; `game-cells.spec.ts` intentionally asserts raw shape to verify the module's own routing.

## Acceptance criteria

- [x] Section membership resolved in exactly one module; no other production module builds a `Set` from `UPPER_CATEGORIES`.
- [x] No production caller indexes `columns.upper` / `.lower` directly.
- [x] Score placement writes via a single `writeCell` call (no inline nested spread).
- [x] Next-unfilled-column, any-score, all-filled, per-column stats, and cell-display all consume the new interface.
- [x] Cell-value assertions go through `readCell`.
- [x] Persisted JSON / localStorage schema unchanged (ADR-0005).

## Test notes

- **Unit:** 277 passed (16 new in `game-cells.spec.ts`). Lint (`eslint .`) and `pnpm typecheck` clean.
- **E2e:** 4 passed; **2 failed** — `report-issue.spec.ts › shows success toast after valid submission` and `› shows error toast when worker returns 429`. These are **pre-existing and unrelated to this branch**: `report-issue.spec.ts`, the report-issue dialog, and `injection-tokens.ts` are byte-identical to `main`, and the failures stem from the Turnstile token input (gated behind `IS_TEST_ENV`, hardcoded `false` at serve time) plus the Cloudflare worker expected on `localhost:8787` — neither available in a plain local `ng serve`. Same code + same `pnpm e2e` server command means they fail identically on `main`. The scoreboard/game flows this PR touches are covered by the unit suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)