### PR TITLE
test: restore report-issue e2e against Angular 22 dev server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,42 @@ jobs:
       - run: pnpm run test --watch=false
       - run: pnpm --filter ./worker/ run test --watch=false
 
+  e2e:
+    runs-on: ubuntu-latest
+    needs: fetch
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: lts/*
+          check-latest: true
+          cache: pnpm
+      - name: Get pnpm store path
+        id: pnpm-store
+        run: echo "store-path=$(pnpm store path)" >> $GITHUB_OUTPUT
+      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ${{ steps.pnpm-store.outputs.store-path }}
+          key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+      - run: pnpm install --offline --frozen-lockfile --recursive
+      - name: Cache Playwright browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('pnpm-lock.yaml') }}
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm run e2e
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
   build:
     runs-on: ubuntu-latest
     needs: [lint, test]

--- a/e2e/report-issue.spec.ts
+++ b/e2e/report-issue.spec.ts
@@ -50,7 +50,7 @@ test.describe('report Issue FAB', () => {
     await page.getByRole('button', { name: /submit/i }).click();
 
     // Dialog should close and toast should be visible
-    await expect(page.getByRole('dialog')).toBeHidden();
+    await expect(page.getByRole('dialog', { name: /report/i })).toBeHidden();
     await expect(page.getByTestId('toast')).toBeVisible({ timeout: 5000 });
     await expect(page.getByTestId('toast')).toHaveClass(/bg-green/);
   });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,10 @@ import { env } from 'node:process';
 
 import { defineConfig, devices } from '@playwright/test';
 
+const HOST = '127.0.0.1';
+const PORT = 4200;
+const BASE_URL = `http://${HOST}:${PORT}`;
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
@@ -10,7 +14,7 @@ export default defineConfig({
   workers: env['CI'] ? 1 : undefined,
   reporter: 'html',
   use: {
-    baseURL: 'http://127.0.0.1:4200',
+    baseURL: BASE_URL,
     trace: 'on-first-retry',
   },
   projects: [
@@ -20,8 +24,15 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'pnpm start',
-    url: 'http://127.0.0.1:4200',
-    reuseExistingServer: !env['CI'],
+    command: `pnpm start --host ${HOST} --port ${PORT}`,
+    url: BASE_URL,
+    env: {
+      /* eslint-disable @typescript-eslint/naming-convention -- environment variable names */
+      NG_APP_IS_TEST_ENV: 'true',
+      NG_APP_REPORT_ISSUE_ENDPOINT: 'http://localhost:8787/report',
+      NG_APP_BUILD_ID: 'e2e-tests',
+      /* eslint-enable @typescript-eslint/naming-convention */
+    },
+    reuseExistingServer: false,
   },
 });

--- a/src/app/services/injection-tokens.ts
+++ b/src/app/services/injection-tokens.ts
@@ -4,7 +4,7 @@ export const [
   // eslint-disable-next-line @typescript-eslint/naming-convention -- injection function
   injectIsTestEnv,,
   IS_TEST_ENV,
-] = createInjectionToken(() => false);
+] = createInjectionToken(() => import.meta.env.NG_APP_IS_TEST_ENV === 'true');
 export const [
   // eslint-disable-next-line @typescript-eslint/naming-convention -- injection function
   injectTurnstileSiteKey,,

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -10,6 +10,7 @@ interface ImportMetaEnv {
   /* eslint-disable @typescript-eslint/naming-convention */
   readonly NG_APP_REPORT_ISSUE_ENDPOINT: string;
   readonly NG_APP_TURNSTILE_SITE_KEY: string;
+  readonly NG_APP_IS_TEST_ENV: string;
   readonly NG_APP_BUILD_ID: string;
   readonly VITEST: boolean;
   /* eslint-enable @typescript-eslint/naming-convention */


### PR DESCRIPTION
## Summary

The report-issue e2e suite broke after the Angular 22 dependency bump (#51). This restores all 6 specs to green.

Two root causes:

1. **WebServer health-check timeout.** The Angular 22 dev server binds to `localhost` (`::1`) only, so `pnpm start` no longer answered on `127.0.0.1` and Playwright's health check timed out (`Timed out waiting 60000ms from config.webServer`). Fixed by forcing the host explicitly via `--host 127.0.0.1` and matching `baseURL`/`url` to it, so binding never depends on the framework default.

2. **Hidden Turnstile input never rendered.** Commit `1f394ae` hard-coded `IS_TEST_ENV` to `false`, so the dialog rendered the real Cloudflare widget instead of the `data-testid="turnstile-token-input"` hidden input the submission specs need. `getByTestId('turnstile-token-input')` then timed out on the success/429 tests. Fixed by reading `NG_APP_IS_TEST_ENV` and providing it (plus the worker endpoint and a build id) through the Playwright `webServer.env`.

## Changes

- `playwright.config.ts`: explicit `HOST`/`PORT`, env vars via `webServer.env`, `reuseExistingServer: false` (kills the stale-server trap where a plain `pnpm start` without test env would be reused)
- `src/app/services/injection-tokens.ts`: `IS_TEST_ENV` reads `NG_APP_IS_TEST_ENV === 'true'`
- `src/vite-env.d.ts`: type `NG_APP_IS_TEST_ENV`
- `e2e/report-issue.spec.ts`: scope dialog locator by accessible name

## Notes

- No backend needed: the Cloudflare worker is not started — submission specs mock `http://localhost:8787/report` via `page.route`.
- This is the author's own intended fix (unmerged commit `6adfb93`), adopted and refined.

## Test plan

- [x] `pnpm e2e` — 6/6 passed
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` (pre-commit) — 261 unit tests passed
- [x] `eslint --fix` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)